### PR TITLE
Manage stops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'paper_trail', '~> 8.1'
 gem 'rails', '~> 5.1'
 gem 'sass-rails', '~> 5.0'
 gem 'underscore-rails', '~> 1.8'
+gem 'will_paginate', '~> 3.1'
 
 group :production do
   gem 'exception_notification', '~> 4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ group :development do
   gem 'capistrano-rails', require: false
   gem 'capistrano-passenger', require: false
   gem 'pry-byebug'
+  gem 'timecop', '~> 0.9.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     underscore-rails (1.8.3)
@@ -231,6 +232,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 5.1)
   sass-rails (~> 5.0)
+  timecop (~> 0.9.1)
   underscore-rails (~> 1.8)
   will_paginate (~> 3.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    will_paginate (3.1.6)
 
 PLATFORMS
   ruby
@@ -231,6 +232,7 @@ DEPENDENCIES
   rails (~> 5.1)
   sass-rails (~> 5.0)
   underscore-rails (~> 1.8)
+  will_paginate (~> 3.1)
 
 BUNDLED WITH
    1.16.1

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery-ui/widgets/autocomplete
+//= require jquery-ui/widgets/datepicker
 //= require underscore
 //= require_tree .

--- a/app/assets/javascripts/bus_stops.js
+++ b/app/assets/javascripts/bus_stops.js
@@ -2,6 +2,10 @@ $(document).ready(function(){
   $('.name-autocomplete').autocomplete({
     source: searchStops
   });
+
+  $('.datepick').datepicker({
+    dateFormat: 'yyyy-mm-dd'
+  })
 });
 
 function searchStops(request, response){

--- a/app/assets/javascripts/bus_stops.js
+++ b/app/assets/javascripts/bus_stops.js
@@ -4,7 +4,7 @@ $(document).ready(function(){
   });
 
   $('.datepick').datepicker({
-    dateFormat: 'yyyy-mm-dd'
+    dateFormat: 'yy-mm-dd'
   })
 });
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
 /*
- *= require autocomplete
+ *= require jquery-ui
  *= require_tree .
  *= require_self
  */

--- a/app/assets/stylesheets/bus_stops/manage.scss
+++ b/app/assets/stylesheets/bus_stops/manage.scss
@@ -1,0 +1,8 @@
+table.manage{
+  td {
+    padding: 0 0.5em;
+  }
+  th {
+    text-align: center;
+  }
+}

--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -1,5 +1,6 @@
 class BusStopsController < ApplicationController
-  before_action :find_stop, only: %i(edit id_search update)
+  before_action :find_stop, only: %i[edit id_search update]
+  before_action :restrict_to_admin, only: %i[manage]
 
   def autocomplete
     stops = BusStop.where 'lower(name) like ?',
@@ -29,6 +30,10 @@ class BusStopsController < ApplicationController
 
   def id_search
     redirect_to edit_bus_stop_path(@stop.hastus_id)
+  end
+
+  def manage
+    @stops = BusStop.order(:name)
   end
 
   def name_search

--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -1,6 +1,6 @@
 class BusStopsController < ApplicationController
-  before_action :find_stop, only: %i[edit id_search update]
-  before_action :restrict_to_admin, only: %i[manage]
+  before_action :find_stop, only: %i[edit destroy id_search update]
+  before_action :restrict_to_admin, only: %i[destroy manage]
 
   def autocomplete
     stops = BusStop.where 'lower(name) like ?',
@@ -26,6 +26,12 @@ class BusStopsController < ApplicationController
       flash[:errors] = @stop.errors.full_messages
       render 'edit'
     end
+  end
+
+  def destroy
+    @stop.destroy
+    redirect_to manage_bus_stops_path,
+      notice: "#{@stop.name} has been deleted."
   end
 
   def id_search
@@ -62,7 +68,8 @@ class BusStopsController < ApplicationController
   def find_stop
     @stop = BusStop.find_by hastus_id: params.require(:id)
     unless @stop.present?
-      redirect_to :back, notice: "Stop #{params[:id]} not found" and return
+      redirect_back(fallback_location: root_path,
+        notice: "Stop #{params[:id]} not found") and return
     end
   end
 

--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -34,6 +34,7 @@ class BusStopsController < ApplicationController
 
   def manage
     @stops = BusStop.order(:name)
+                    .paginate(page: params[:page], per_page: 10)
   end
 
   def name_search

--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -59,7 +59,10 @@ class BusStopsController < ApplicationController
                     .paginate(page: params[:page], per_page: 10)
     respond_to do |format|
       format.html { render :outdated }
-      # format.csv
+      format.csv do
+        send_data @stops.to_csv,
+          filename: "outdated-stops-since-#{@date.strftime('%Y%m%d')}.csv"
+      end
     end
   end
 

--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -41,6 +41,13 @@ class BusStopsController < ApplicationController
   def manage
     @stops = BusStop.order(:name)
                     .paginate(page: params[:page], per_page: 10)
+    respond_to do |format|
+      format.html { render :manage }
+      format.csv do
+        send_data @stops.to_csv,
+          filename: "all-stops-#{Date.today.strftime('%Y%m%d')}.csv"
+      end
+    end
   end
 
   def name_search
@@ -60,7 +67,7 @@ class BusStopsController < ApplicationController
     respond_to do |format|
       format.html { render :outdated }
       format.csv do
-        send_data @stops.to_csv,
+        send_data @stops.to_csv(limited_attributes: true),
           filename: "outdated-stops-since-#{@date.strftime('%Y%m%d')}.csv"
       end
     end

--- a/app/models/bus_stop.rb
+++ b/app/models/bus_stop.rb
@@ -37,7 +37,8 @@ class BusStop < ApplicationRecord
   EXPORT_ATTRS = {
     name: 'Stop Name',
     hastus_id: 'Hastus ID',
-    route_list: 'Routes'
+    route_list: 'Routes',
+    updated_at: 'Last updated'
   }
 
   STRING_COLUMN_OPTIONS.each do |attribute, options|

--- a/app/models/bus_stop.rb
+++ b/app/models/bus_stop.rb
@@ -34,7 +34,7 @@ class BusStop < ApplicationRecord
   BOOLEAN_COLUMNS = %i(bolt_on_base bus_pull_out_exists extend_pole has_power
     new_anchor new_pole solar_lighting straighten_pole system_map_exists)
 
-  EXPORT_ATTRS = {
+  LIMITED_ATTRS = {
     name: 'Stop Name',
     hastus_id: 'Hastus ID',
     route_list: 'Routes',
@@ -64,11 +64,15 @@ class BusStop < ApplicationRecord
     routes.pluck(:number).sort.join(', ')
   end
 
-  def self.to_csv
+  def self.to_csv(limited_attributes: false)
+    attrs = if limited_attributes
+              LIMITED_ATTRS
+            else Hash[columns.map{|c| [c.name, c.name.humanize] }]
+            end
     CSV.generate headers: true do |csv|
-       csv << EXPORT_ATTRS.values
+       csv << attrs.values
        all.each do |stop|
-         csv << EXPORT_ATTRS.keys.map { |attr| stop.send attr }
+         csv << attrs.keys.map { |attr| stop.send attr }
        end
     end
   end

--- a/app/models/bus_stop.rb
+++ b/app/models/bus_stop.rb
@@ -5,9 +5,10 @@ class BusStop < ApplicationRecord
   validates :name, presence: true
   validates :hastus_id, presence: true, uniqueness: true
   has_and_belongs_to_many :routes
-  default_scope -> { order :name }
 
   before_save :assign_completion_timestamp, if: -> { completed_changed? }
+
+  scope :not_updated_since, -> (date) { where 'updated_at < ?', date.to_datetime }
 
   STRING_COLUMN_OPTIONS = {
     accessible: ['When necessary', 'Not recommended'],
@@ -48,6 +49,10 @@ class BusStop < ApplicationRecord
 
   def last_updated_by
     User.find_by(id: last_updated.try(:whodunnit)).try :name || 'Unknown'
+  end
+
+  def route_list
+    routes.pluck(:number).sort.join(', ')
   end
 
   private

--- a/app/models/bus_stop.rb
+++ b/app/models/bus_stop.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 include DateAndTimeMethods
 
 class BusStop < ApplicationRecord
@@ -32,6 +34,12 @@ class BusStop < ApplicationRecord
   BOOLEAN_COLUMNS = %i(bolt_on_base bus_pull_out_exists extend_pole has_power
     new_anchor new_pole solar_lighting straighten_pole system_map_exists)
 
+  EXPORT_ATTRS = {
+    name: 'Stop Name',
+    hastus_id: 'Hastus ID',
+    route_list: 'Routes'
+  }
+
   STRING_COLUMN_OPTIONS.each do |attribute, options|
     validates attribute, inclusion: { in: options }, allow_blank: true
   end
@@ -53,6 +61,15 @@ class BusStop < ApplicationRecord
 
   def route_list
     routes.pluck(:number).sort.join(', ')
+  end
+
+  def self.to_csv
+    CSV.generate headers: true do |csv|
+       csv << EXPORT_ATTRS.values
+       all.each do |stop|
+         csv << EXPORT_ATTRS.keys.map { |attr| stop.send attr }
+       end
+    end
   end
 
   private

--- a/app/views/bus_stops/manage.haml
+++ b/app/views/bus_stops/manage.haml
@@ -2,8 +2,13 @@
   %thead
     %th Stop
     %th ID
+    %th
+    %th
   - @stops.each do |stop|
     %tr
       %td= stop.name
       %td= stop.hastus_id
+      %td= link_to 'Edit', edit_bus_stop_path(stop.hastus_id)
+      %td= button_to 'Delete', bus_stop_path(stop.hastus_id), method: :delete,
+        data: { confirm: "Are you sure you want to delete #{stop.name}? This cannot be undone." }
 = will_paginate @stops

--- a/app/views/bus_stops/manage.haml
+++ b/app/views/bus_stops/manage.haml
@@ -6,3 +6,4 @@
     %tr
       %td= stop.name
       %td= stop.hastus_id
+= will_paginate @stops

--- a/app/views/bus_stops/manage.haml
+++ b/app/views/bus_stops/manage.haml
@@ -1,4 +1,6 @@
 = link_to 'View Outdated', outdated_bus_stops_path
+%br
+= link_to 'Export all as CSV', manage_bus_stops_path(format: :csv)
 
 %table.manage
   %thead

--- a/app/views/bus_stops/manage.haml
+++ b/app/views/bus_stops/manage.haml
@@ -1,13 +1,17 @@
+= link_to 'View Outdated', outdated_bus_stops_path
+
 %table.manage
   %thead
     %th Stop
     %th ID
+    %th Routes
     %th
     %th
   - @stops.each do |stop|
     %tr
       %td= stop.name
       %td= stop.hastus_id
+      %td= stop.route_list
       %td= link_to 'Edit', edit_bus_stop_path(stop.hastus_id)
       %td= button_to 'Delete', bus_stop_path(stop.hastus_id), method: :delete,
         data: { confirm: "Are you sure you want to delete #{stop.name}? This cannot be undone." }

--- a/app/views/bus_stops/manage.haml
+++ b/app/views/bus_stops/manage.haml
@@ -1,0 +1,8 @@
+%table.manage
+  %thead
+    %th Stop
+    %th ID
+  - @stops.each do |stop|
+    %tr
+      %td= stop.name
+      %td= stop.hastus_id

--- a/app/views/bus_stops/outdated.haml
+++ b/app/views/bus_stops/outdated.haml
@@ -1,0 +1,24 @@
+Bus stops not updated since #{@date} (#{@stops.count})
+
+= form_tag '#' do
+  = text_field_tag :date, @date, class: 'datepick'
+  = submit_tag 'Change date'
+
+- if @stops.present?
+  %table.manage
+    %thead
+      %th Stop
+      %th ID
+      %th Routes
+      %th Updated
+      %th
+    - @stops.each do |stop|
+      %tr
+        %td= stop.name
+        %td= stop.hastus_id
+        %td= stop.route_list
+        %td= stop.updated_at.strftime('%Y-%m-%d %H:%M %P')
+        %td= link_to 'Edit', edit_bus_stop_path(stop.hastus_id)
+  = will_paginate @stops
+- else
+  No such stops.

--- a/app/views/bus_stops/outdated.haml
+++ b/app/views/bus_stops/outdated.haml
@@ -1,8 +1,10 @@
 Bus stops not updated since #{@date} (#{@stops.count})
 
-= form_tag '#' do
+= form_tag '#', method: :get do
   = text_field_tag :date, @date, class: 'datepick'
   = submit_tag 'Change date'
+
+= link_to 'Export as CSV', outdated_bus_stops_path(date: params[:date], format: :csv)
 
 - if @stops.present?
   %table.manage

--- a/app/views/layouts/_navbar.haml
+++ b/app/views/layouts/_navbar.haml
@@ -4,10 +4,12 @@
       %a.navbar-brand{href: root_path}= image_tag 'favicon.png'
     - if user_signed_in?
       = link_to new_bus_stop_path do
-        %button.btn.btn-default.navbar-btn.navbar-left New Bus Stop
+        %button.btn.btn-default.navbar-btn.navbar-left New Stop
       - if current_user.admin?
         = link_to new_user_path do
           %button.btn.btn-default.navbar-btn.navbar-left New User
+        = link_to manage_bus_stops_path do
+          %button.btn.btn-default.navbar-btn.navbar-left Manage Stops
         = link_to users_path do
           %button.btn.btn-default.navbar-btn.navbar-left Manage Users
       = link_to destroy_user_session_path, method: :delete do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       post :id_search
       get  :manage
       post :name_search
+      get  :outdated
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       post :autocomplete
       get  :by_route
       post :id_search
+      get  :manage
       post :name_search
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require 'timecop'
+
 User.create! name: 'David Faulkenberry',
              email: 'dave@example.com',
              password: 'password',
@@ -41,9 +43,12 @@ hastus_ids = {
 
 stops.each do |route_number, stop_names|
   stop_names.each do |stop_name|
-    stop = BusStop.find_or_initialize_by name: stop_name
-    stop.hastus_id = hastus_ids.fetch(stop_name)
-    stop.routes << routes.fetch(route_number)
-    stop.save!
+    # Anytime in the last two months
+    Timecop.freeze rand(86_400).minutes.ago do
+      stop = BusStop.find_or_initialize_by name: stop_name
+      stop.hastus_id = hastus_ids.fetch(stop_name)
+      stop.routes << routes.fetch(route_number)
+      stop.save!
+    end
   end
 end


### PR DESCRIPTION
Closes #18.

Link to new interface in navbar:

<img width="1437" alt="screen shot 2018-03-20 at 5 41 58 pm" src="https://user-images.githubusercontent.com/3988134/37684310-060684ca-2c66-11e8-8a09-90b8b53931f9.png">

Management interface:

<img width="1440" alt="screen shot 2018-03-20 at 5 42 16 pm" src="https://user-images.githubusercontent.com/3988134/37684321-10cc7658-2c66-11e8-8d77-467538eeebde.png">

Includes pagination:

<img width="1290" alt="screen shot 2018-03-20 at 5 42 31 pm" src="https://user-images.githubusercontent.com/3988134/37684337-18e04d88-2c66-11e8-8094-f6a3104bf9e1.png">

Can view outdated stops:

<img width="1437" alt="screen shot 2018-03-20 at 5 42 48 pm" src="https://user-images.githubusercontent.com/3988134/37684358-28f5d468-2c66-11e8-8e31-23dfa47d3285.png">

Including a datepicker:

<img width="896" alt="screen shot 2018-03-20 at 5 43 18 pm" src="https://user-images.githubusercontent.com/3988134/37684373-33d7e4a2-2c66-11e8-9015-cfa4031ce0a0.png">

And can export as CSV:

<img width="384" alt="screen shot 2018-03-20 at 5 43 43 pm" src="https://user-images.githubusercontent.com/3988134/37684400-4ae73530-2c66-11e8-8123-416c8f3797cf.png">
