### PR TITLE
Convert moderns

### DIFF
--- a/lib/tasks/stop_data_convert_and_import.rake
+++ b/lib/tasks/stop_data_convert_and_import.rake
@@ -29,4 +29,13 @@ namespace :bus_stops do
       stop.update_attributes(new_attributes)
     end
   end
+  task import_shelter_type_data: :environment do
+    csv = CSV.read('all_stop_data.csv', headers: true)
+    csv.each do |row|
+      shelter_type = {}
+      shelter_type['shelter_type'] = row['shelter_type'] if 'Modern' then 'Modern Full'
+      stop = BusStop.find row['id']
+      stop.update_attributes(shelter_type)
+    end
+  end
 end

--- a/lib/tasks/stop_data_convert_and_import.rake
+++ b/lib/tasks/stop_data_convert_and_import.rake
@@ -34,7 +34,7 @@ namespace :bus_stops do
     csv.each do |row|
       shelter_type = {}
       shelter_type['shelter_type'] = case row['shelter_type']
-                                     when 'Modern' then 'Modern Full'
+                                     when 'Modern' then 'Modern full'
                                      end
       stop = BusStop.find row['id']
       stop.update_attributes(shelter_type)

--- a/lib/tasks/stop_data_convert_and_import.rake
+++ b/lib/tasks/stop_data_convert_and_import.rake
@@ -33,9 +33,10 @@ namespace :bus_stops do
     csv = CSV.read('all_stop_data.csv', headers: true)
     csv.each do |row|
       attrs = {}
-      attrs['shelter_type'] = case row['shelter_type']
-                                     when 'Modern' then 'Modern full'
-                                     end
+      if row['shelter_type'] == 'Modern'
+        attrs['shelter_type'] = 'Modern full'
+      else attrs['shelter_type'] = row['shelter_type']
+      end
       stop = BusStop.find row['id']
       stop.update_attributes(attrs)
     end

--- a/lib/tasks/stop_data_convert_and_import.rake
+++ b/lib/tasks/stop_data_convert_and_import.rake
@@ -33,7 +33,9 @@ namespace :bus_stops do
     csv = CSV.read('all_stop_data.csv', headers: true)
     csv.each do |row|
       shelter_type = {}
-      shelter_type['shelter_type'] = row['shelter_type'] if 'Modern' then 'Modern Full'
+      shelter_type['shelter_type'] = case row['shelter_type']
+                                     when 'Modern' then 'Modern Full'
+                                     end
       stop = BusStop.find row['id']
       stop.update_attributes(shelter_type)
     end

--- a/lib/tasks/stop_data_convert_and_import.rake
+++ b/lib/tasks/stop_data_convert_and_import.rake
@@ -32,12 +32,12 @@ namespace :bus_stops do
   task import_shelter_type_data: :environment do
     csv = CSV.read('all_stop_data.csv', headers: true)
     csv.each do |row|
-      shelter_type = {}
-      shelter_type['shelter_type'] = case row['shelter_type']
+      attrs = {}
+      attrs['shelter_type'] = case row['shelter_type']
                                      when 'Modern' then 'Modern full'
                                      end
       stop = BusStop.find row['id']
-      stop.update_attributes(shelter_type)
+      stop.update_attributes(attrs)
     end
   end
 end

--- a/lib/tasks/stop_data_export.rake
+++ b/lib/tasks/stop_data_export.rake
@@ -17,8 +17,8 @@ namespace :bus_stops do
   end
   task export_modern_shelter_data: :environment do
     attributes = BusStop.attribute_names
-    CSV.open('shelter_type_stop_data.csv', 'w', write_headers: true, headers: attributes) do |csv|
-      BusStop.where(shelter_type: 'Modern').each do |stop|
+    CSV.open('all_stop_data.csv', 'w', write_headers: true, headers: attributes) do |csv|
+      BusStop.all.each do |stop|
         csv << attributes.map{|attr| stop.send(attr)}
       end
     end

--- a/lib/tasks/stop_data_export.rake
+++ b/lib/tasks/stop_data_export.rake
@@ -16,7 +16,7 @@ namespace :bus_stops do
     end
   end
   task export_modern_shelter_data: :environment do
-    attributes = #something
+    attributes = BusStop.attribute_names
     CSV.open('shelter_type_stop_data.csv', 'w', write_headers: true, headers: attributes) do |csv|
       BusStop.where(shelter_type: 'Modern').each do |stop|
         csv << attributes.map{|attr| stop.send(attr)}

--- a/lib/tasks/stop_data_export.rake
+++ b/lib/tasks/stop_data_export.rake
@@ -15,4 +15,12 @@ namespace :bus_stops do
       end
     end
   end
+  task export_modern_shelter_data: :environment do
+    attributes = #something
+    CSV.open('shelter_type_stop_data.csv', 'w', write_headers: true, headers: attributes) do |csv|
+      BusStop.where(shelter_type: 'Modern').each do |stop|
+        csv << attributes.map{|attr| stop.send(attr)}
+      end
+    end
+  end
 end


### PR DESCRIPTION
For about a month, we had the choice of "Modern" for `shelter_type,` but eventually changed it to the correct value of "Modern Full." @sherson requested that I change production `shelter_type` entries of "Modern" to "Modern Full." 

Made two separate rake tasks to do the job -- one to save all current bus stop data to a csv (in case this is _not_ an ideal change) and the other to import the csv and update those particular bus stops.