### PR TITLE
Remove DateTimeMethods lib

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,8 @@
 class ApplicationController < ActionController::Base
-  include DateAndTimeMethods
-
   protect_from_forgery with: :exception
   before_action :authenticate_user!
   before_action :set_paper_trail_whodunnit
   before_action :prepare_exception_notifier
-
-  helper_method :format_datetime
 
   private
 
@@ -15,7 +11,7 @@ class ApplicationController < ActionController::Base
     request.env['exception_notifier.exception_data']
            .merge(current_user: current_user)
   end
-  
+
   def restrict_to_admin
     head :unauthorized and return unless current_user.admin?
   end

--- a/app/models/bus_stop.rb
+++ b/app/models/bus_stop.rb
@@ -3,7 +3,6 @@
 require 'csv'
 
 class BusStop < ApplicationRecord
-  include DateAndTimeMethods
   has_paper_trail
   validates :name, presence: true
   validates :hastus_id, presence: true, uniqueness: true
@@ -197,7 +196,7 @@ class BusStop < ApplicationRecord
 
   def last_updated_at
     if last_updated.present?
-      format_datetime last_updated.created_at
+      last_updated.created_at.to_formatted_s(:long_with_time)
     else 'Unknown'
     end
   end

--- a/app/views/bus_stops/_form.haml
+++ b/app/views/bus_stops/_form.haml
@@ -3,7 +3,8 @@
     Last updated by #{stop.last_updated_by} at #{stop.last_updated_at}
 - if stop.completed_at.present?
   .smalltext.last-updated
-    Completed by #{stop.completed_by.try :name} at #{format_datetime stop.completed_at}
+    Completed by #{stop.completed_by.try :name}
+    at #{stop.completed_at.to_formatted_s(:long_with_time)}
 = form_for stop, url: bus_stop_path(stop.hastus_id) do |f|
   %table.edit-form
     %th

--- a/app/views/bus_stops/outdated.haml
+++ b/app/views/bus_stops/outdated.haml
@@ -19,7 +19,7 @@ Bus stops not updated since #{@date} (#{@stops.count})
         %td= stop.name
         %td= stop.hastus_id
         %td= stop.route_list
-        %td= stop.updated_at.strftime('%Y-%m-%d %H:%M %P')
+        %td= stop.updated_at.to_formatted_s :db_hm
         %td= link_to 'Edit', edit_bus_stop_path(stop.hastus_id)
   = will_paginate @stops
 - else

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,6 @@ module StopProject
     # the framework and any gems in your application.
     config.encoding = 'utf-8'
     config.time_zone = 'Eastern Time (US & Canada)'
-    config.autoload_paths << Rails.root.join('lib')
     config.filter_parameters += [:password, :secret]
   end
 end

--- a/config/initializers/custom_time_formats.rb
+++ b/config/initializers/custom_time_formats.rb
@@ -1,0 +1,5 @@
+# Wednesday, February 5, 2020 - 2:22 pm
+Time::DATE_FORMATS[:long_with_time] = '%A, %B %-d, %Y - %-l:%M %P'
+Date::DATE_FORMATS[:long_with_time] = '%A, %B %-d, %Y - %-l:%M %P'
+
+Time::DATE_FORMATS[:db_hm] = '%F %R'

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 91.51
+    "covered_percent": 91.3
   }
 }

--- a/lib/date_and_time_methods.rb
+++ b/lib/date_and_time_methods.rb
@@ -1,5 +1,0 @@
-module DateAndTimeMethods
-  def format_datetime(datetime)
-    datetime.strftime('%A, %B %e, %Y - %l:%M %P').squish
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'factory_bot_rails'
 
 ActiveRecord::Migration.maintain_test_schema!
 Capybara.default_driver = :selenium
+
 RSpec.configure do |config|
   config.order = :random
   config.include FactoryBot::Syntax::Methods
@@ -26,12 +27,15 @@ RSpec.configure do |config|
   config.before :all do
     FactoryBot.reload
   end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
+
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
@@ -43,12 +47,4 @@ def when_current_user_is(user)
                  when Symbol then create(:user, user)
                  end
   sign_in current_user
-end
-
-def format_time(time)
-  time.strftime('%Y-%m-%d %H:%M %P')
-end
-
-def format_datetime(datetime)
-  datetime.strftime('%A, %B%e, %Y - %l:%M %P')
 end

--- a/spec/system/bus_stops/editing_bus_stops_spec.rb
+++ b/spec/system/bus_stops/editing_bus_stops_spec.rb
@@ -77,7 +77,8 @@ describe 'editing a bus stop as a user' do
       Timecop.freeze Date.today do
         when_current_user_is user
         visit edit_bus_stop_path(edit_stop.hastus_id)
-        expect(page).to have_content "Last updated by #{last_user.name} at #{format_datetime(Date.yesterday)}"
+        updated = Date.yesterday.to_formatted_s(:long_with_time)
+        expect(page).to have_content "Last updated by #{last_user.name} at #{updated}"
       end
     end
   end
@@ -98,7 +99,8 @@ describe 'editing a bus stop as a user' do
       Timecop.freeze Date.today do
         when_current_user_is user
         visit edit_bus_stop_path(edit_stop.hastus_id)
-        expect(page).to have_content "Completed by #{last_user.name} at #{format_datetime(Date.yesterday)}"
+        completed = Date.yesterday.to_formatted_s(:long_with_time)
+        expect(page).to have_content "Completed by #{last_user.name} at #{completed}"
       end
     end
   end

--- a/spec/system/bus_stops/managing_bus_stops_spec.rb
+++ b/spec/system/bus_stops/managing_bus_stops_spec.rb
@@ -55,14 +55,14 @@ describe 'viewing outdated' do
     expect(page).to have_selector 'table.manage tbody tr',
                                   count: 2
     expect(page).to have_selector 'table.manage tbody tr',
-                                  text: format_time(old_stop_1.updated_at)
+                                  text: old_stop_1.updated_at.to_formatted_s(:db_hm)
     expect(page).to have_selector 'table.manage tbody tr',
-                                  text: format_time(old_stop_2.updated_at)
+                                  text: old_stop_2.updated_at.to_formatted_s(:db_hm)
     expect(page).not_to have_selector 'table.manage tbody tr',
-                                      text: format_time(present_stop.updated_at)
+                                  text: present_stop.updated_at.to_formatted_s(:db_hm)
   end
   it 'allows editing of outdated stops' do
-    within 'tr', text: format_time(old_stop_1.updated_at) do
+    within 'tr', text: old_stop_1.updated_at.to_formatted_s(:db_hm) do
       click_link 'Edit'
     end
     expect(page).to have_content "Editing #{old_stop_1.name}"


### PR DESCRIPTION
A lib full of time-formatting methods is something I'd rather not borrow from round-three. Use the Rails custom formatters instead.