### PR TITLE
Fix "inclusion in" validations

### DIFF
--- a/app/models/bus_stop.rb
+++ b/app/models/bus_stop.rb
@@ -172,9 +172,9 @@ class BusStop < ApplicationRecord
     technology: TECHNOLOGY
   }.freeze
 
-  SUPER_HASH.each do |hash|
-    hash.each do |name, options|
-      validates name, inclusion: { in: options }, allow_blank: true if options.is_a?(Array)
+  SUPER_HASH.each do |_, subhash|
+    subhash.each do |field, options|
+      validates field, inclusion: { in: options }, allow_blank: true if options.is_a?(Array)
     end
   end
 

--- a/spec/factories/bus_stops.rb
+++ b/spec/factories/bus_stops.rb
@@ -12,11 +12,11 @@ FactoryBot.define do
       mounting { 'Structure' }
       mounting_direction { 'Towards street' }
       schedule_holder { 'None' }
-      shelter { 'Building' }
+      shelter { 'PVTA shelter' }
       sidewalk_width { 'Less than 36 inches' }
       trash { 'Municipal' }
-      mounting_clearance { '60-83 inches' }
-      sign_type { 'Rectangle (<2014)' }
+      mounting_clearance { '60-84 inches' }
+      sign_type { 'Rectangle' }
       shelter_condition { 'Poor' }
       shelter_pad_condition { 'Great' }
       shelter_pad_material { 'Asphalt' }
@@ -26,15 +26,15 @@ FactoryBot.define do
       obstructions { 'Yes - Bollard/Structure' }
       stop_sticker { 'Sticker correct' }
       route_stickers { 'No stickers' }
-      bike_rack { 'Bike locker' }
+      bike_rack { 'Other bike rack' }
       real_time_information { 'Yes - Solar' }
       created_at { 2.days.ago }
       updated_at { 1.day.ago }
       bolt_on_base { true }
       bus_pull_out_exists { true }
-      has_power { true }
+      has_power { 'No' }
       solar_lighting { true }
-      system_map_exists { true }
+      system_map_exists { 'No map' }
       shelter_ada_compliant { true }
       ada_landing_pad { true }
       state_road { true }


### PR DESCRIPTION
`SUPER_HASH` is, unsurprisingly, a Hash. If you iterate through it with only one iteration variable, then you get arrays with two values.

Because of the conditional tacked onto `validates`, this caused these validations to never run.