### PR TITLE
Don't use a JS compressor

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,6 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScript and CSS.
-  config.assets.js_compressor = :uglifier
   config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Uglifier doesn't like ES6 syntax.

The [default in a new Rails app](https://github.com/railsdiff/rails-new-output/blob/main/config/environments/production.rb) is not to bother. Kinda the whole deal with importmaps is that the browser manages it; you don't have to compile a huge compressed JS file.