### PR TITLE
Use a more recent recent LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: jammy
 language: ruby
 cache: bundler
 addons:


### PR DESCRIPTION
Xenial, 16.04 is still the default. Jammy, 22.04, _isn't_ the most recent LTS, but it's the most recent one on Travis.

We've been having quite a few unexplained build failures recently. This is mostly grasping at straws, but it can't _hurt_ to get off of an 8-year-old, unsupported version of Ubuntu :shrug: