### PR TITLE
Fix redirecting to edit on form error

### DIFF
--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -60,7 +60,7 @@ class BusStopsController < ApplicationController
       end
     else
       flash[:errors] = @stop.errors.full_messages
-      render 'edit'
+      render 'edit', status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
       redirect_to users_path
     else
       flash[:errors] = @user.errors.full_messages
-      render 'edit'
+      render 'edit', status: :unprocessable_entity
     end
   end
 
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
       redirect_to users_path
     else
       flash[:errors] = @user.errors.full_messages
-      render 'edit'
+      render 'edit', status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
Turbo needs an error status to know what to do with the error. This was broken by #250 - currently the user doesn't get validation feedback, and there's an error in the browser console.