### PR TITLE
Fix mistakenly removed dep for rubocop-capybara

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,7 @@ GEM
     rubocop-ast (1.33.0)
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
+      rubocop (~> 1.41)
     rubocop-factory_bot (2.25.1)
       rubocop (~> 1.41)
     rubocop-rails (2.27.0)


### PR DESCRIPTION
This line was mistakenly removed in 5c4206e7571cf74399f5e9d36adf76816ddc0224