### PR TITLE
Remove Timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ group :development, :test do
   gem 'debug'
   gem 'factory_bot_rails'
   gem 'listen'
-  gem 'timecop'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,7 +406,6 @@ GEM
     temple (0.10.4)
     thor (1.4.0)
     tilt (2.6.1)
-    timecop (0.9.10)
     timeout (0.4.3)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
@@ -479,7 +478,6 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   strong_password
-  timecop
   turbo-rails
   uglifier
 
@@ -637,7 +635,6 @@ CHECKSUMS
   temple (0.10.4) sha256=b7a1e94b6f09038ab0b6e4fe0126996055da2c38bec53a8a336f075748fff72c
   thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d
   tilt (2.6.1) sha256=35a99bba2adf7c1e362f5b48f9b581cce4edfba98117e34696dde6d308d84770
-  timecop (0.9.10) sha256=12ba45ce57cdcf6b1043cb6cdffa6381fd89ce10d369c28a7f6f04dc1b0cd8eb
   timeout (0.4.3) sha256=9509f079b2b55fe4236d79633bd75e34c1c1e7e3fb4b56cb5fda61f80a0fe30e
   turbo-rails (2.0.16) sha256=d24e1b60f0c575b3549ecda967e5391027143f8220d837ed792c8d48ea0ea38d
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,10 @@
 
 exit unless Rails.env.development?
 
-require 'timecop'
+require 'active_support/testing/time_helpers'
+module TimeTraveler
+  extend ActiveSupport::Testing::TimeHelpers
+end
 
 FactoryBot.create :user, name: 'Admin User', email: 'admin@example.com', admin: true
 FactoryBot.create :user, name: 'Non-Admin User', email: 'user@example.com', admin: false
@@ -45,8 +48,7 @@ hastus_ids = {
 stops.each do |route_number, stops_and_directions|
   stops_and_directions.each do |direction, stop_names|
     stop_names.each.with_index(1) do |stop_name, sequence|
-      # Anytime in the last two months
-      Timecop.freeze rand(86_400).minutes.ago do
+      TimeTraveler.travel_to rand(2.months).seconds.ago do
         stop = BusStop.find_or_initialize_by name: stop_name
         stop.hastus_id = hastus_ids.fetch(stop_name)
         stop.save!

--- a/spec/system/bus_stops/editing_bus_stops_spec.rb
+++ b/spec/system/bus_stops/editing_bus_stops_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe 'editing a bus stop as a user' do
+  include ActiveSupport::Testing::TimeHelpers
+
   let!(:user) { create :user }
   let!(:edit_stop) { create :bus_stop }
 
@@ -68,7 +70,7 @@ RSpec.describe 'editing a bus stop as a user' do
     let(:edit_stop) { create :bus_stop }
 
     before do
-      Timecop.freeze Date.yesterday do
+      travel_to Date.yesterday do
         when_current_user_is last_user
         visit edit_bus_stop_path(edit_stop.hastus_id)
         click_on 'Save stop'
@@ -90,7 +92,7 @@ RSpec.describe 'editing a bus stop as a user' do
     let(:edit_stop) { create :bus_stop, :pending }
 
     before do
-      Timecop.freeze Date.yesterday do
+      travel_to Date.yesterday do
         when_current_user_is last_user
         visit edit_bus_stop_path(edit_stop.hastus_id)
 


### PR DESCRIPTION
Was reading a "gems you probably don't need" blog post and discovered that time-travel is build into Rails (since 4.1)