### PR TITLE
Return disabling of asset compilation

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,8 @@ Rails.application.configure do
   config.assets.css_compressor = :sass
   # Cache assets for far-future expiry since they are all digest stamped.
   config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  # Do not fall back to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
In the barrage of exceptions this weekend, I noticed a few errors related to updating the assets cache, which we shouldn't be trying to do anyways.

This was removed in #487, because Sprockets is no longer the Rails default, but we still have it.