### PR TITLE
Add a shared cache dir for rack-attack

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ set :deploy_to, "/srv/#{fetch :application}"
 set :log_level, :info
 
 append :linked_files, 'config/database.yml'
-append :linked_dirs, '.bundle', 'log'
+append :linked_dirs, '.bundle', 'log', 'tmp/cache'
 
 set :passenger_restart_with_sudo, true
 set :bundle_version, 4


### PR DESCRIPTION
So that its ownership/permissions can remain fixed

Turns out that I broke this app in production in #563 in a similar way to round-three, but... nobody noticed for 3 months :grimacing: ?